### PR TITLE
JENKINS-73368 Jenkins master slave credential access fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ work
 .settings
 .classpath
 .project
+
+# VS Code project files
+.vscode

--- a/src/main/java/io/jenkins/plugins/digicert/Constants.java
+++ b/src/main/java/io/jenkins/plugins/digicert/Constants.java
@@ -1,0 +1,8 @@
+package io.jenkins.plugins.digicert;
+
+public class Constants {
+    public static final String HOST_ID = "SM_HOST";
+    public static final String API_KEY_ID = "SM_API_KEY";
+    public static final String CLIENT_CERT_FILE_ID = "SM_CLIENT_CERT_FILE";
+    public static final String CLIENT_CERT_PASSWORD_ID = "SM_CLIENT_CERT_PASSWORD";
+}


### PR DESCRIPTION
Jenkins credential manager expects the Jenkins instance when it is querying for credentials.
This is not available on the agent due to the limited API.

Refactored flow to pull credentials before the call is passed down to the agent.