### PR TITLE
Graceful failure handling for setting PATH on a remote agent

### DIFF
--- a/src/main/java/io/jenkins/plugins/digicert/Linux.java
+++ b/src/main/java/io/jenkins/plugins/digicert/Linux.java
@@ -56,7 +56,7 @@ public class Linux {
 
     public Integer install(String os) {
         this.listener.getLogger().println("\nAgent type: " + os);
-        var downloadUrl = String.format(
+        String downloadUrl = String.format(
                 "https://%s/signingmanager/api-ui/v1/releases/noauth/smtools-linux-x64.tar.gz/download",
                 SM_HOST.trim().substring(19).replaceAll("/$", ""));
         this.listener.getLogger()

--- a/src/main/java/io/jenkins/plugins/digicert/Windows.java
+++ b/src/main/java/io/jenkins/plugins/digicert/Windows.java
@@ -64,7 +64,7 @@ public class Windows {
 
     public Integer install(String os) {
         this.listener.getLogger().println("\nAgent type: " + os);
-        var downloadUrl = String
+        String downloadUrl = String
                 .format("https://%s/signingmanager/api-ui/v1/releases/noauth/smtools-windows-x64.msi/download",
                         SM_HOST.trim().substring(19).replaceAll("/$", ""));
         this.listener.getLogger()


### PR DESCRIPTION
Fixes made:
- PATH setting on remote agents fail gracefully and show a guidance message now to set up manually

### Testing done
Verified this works on a Jenkins setup with remote agent. This is the use case where the plugin was failing

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->